### PR TITLE
Added npm install for GitHub Action to Update VMs

### DIFF
--- a/.github/workflows/PullToVM.yaml
+++ b/.github/workflows/PullToVM.yaml
@@ -20,5 +20,6 @@ jobs:
         script: |
           if [ ! -d "/home/ubuntu/storybook" ]; then git clone https://${{ secrets.VM_USER_TOKEN }}@github.com/BITNULLS/storybook.git; else cd storybook; git restore *; git pull; cd ..; fi
           cd storybook/edu-storybook/
+          npm install
           npm run build
           exit


### PR DESCRIPTION
Previous PR for #187 caused the github actions to fail. This adds the `npm install` to install anything missing.