### PR TITLE
Quiz Submit Now Returns Correct Answer

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1030,7 +1030,7 @@ def quiz_submit_answer():
             "fail_no": 2,
             "message": "Either the answer_id or the question_id contained invalid characters."
         }, 400, {"Content-Type": "application/json"}
-    '''
+    
     # make sure the user is authenticated first
     auth = request.cookies.get('Authorization')
     vl = validate_login(
@@ -1041,11 +1041,12 @@ def quiz_submit_answer():
         return vl
 
     if 'Bearer ' in auth:
-        auth = auth.replace('Bearer ', '', 1)
+        auth = auth.replace('Bearer ', '', 1) 
+    
     token = jwt.decode(auth, jwt_key, algorithms=config['jwt_alg'])
-    '''
+    
     cursor = connection.cursor()
-    '''
+    
     try:
         conn_lock.acquire()
         cursor.execute(
@@ -1063,12 +1064,14 @@ def quiz_submit_answer():
         }, 400, {"Content-Type": "application/json"}
     finally:
         conn_lock.release()
-        '''
+        
     try:
        conn_lock.acquire()
        cursor.execute(
            "SELECT correct FROM answer WHERE answer_id= " + str(answer_id) + " and question_id= " + str(question_id)
        )
+       label_results_from(cursor)
+       
        connection.commit()
     except cx_Oracle.Error as e:
        return {
@@ -1082,15 +1085,15 @@ def quiz_submit_answer():
 
     result = cursor.fetchone()
 
-    if result[0] == 1:
+    if result['CORRECT']:
        return {
            "status": "ok",
-           "correct": "true"
+           "correct": True
        }
-    elif result[0] == 0:
+    elif ~result['CORRECT']:
        return {
            "status": "ok",
-           "correct": "false"
+           "correct": False
        }
     return {
            "status": "fail",


### PR DESCRIPTION
Solves issue #195 

Identifies the correct answer when submitting quiz question with four choices:
<img width="580" alt="Screen Shot 2022-02-22 at 12 38 34 PM" src="https://user-images.githubusercontent.com/44467999/155190630-b4f56f0b-bb53-4a2f-a2ee-d93940958eca.png">

Here are the answer_id and question_id in database (lines 11-14):
<img width="838" alt="Screen Shot 2022-02-22 at 12 55 30 PM" src="https://user-images.githubusercontent.com/44467999/155190970-546b9d10-680d-426e-bc3f-458f615f3944.png">

And also incorrect (answer_id: 182, 183, 185):
<img width="495" alt="Screen Shot 2022-02-22 at 12 38 52 PM" src="https://user-images.githubusercontent.com/44467999/155190699-18095b16-a900-4473-8c82-5495787b59cc.png">

<img width="475" alt="Screen Shot 2022-02-22 at 1 06 24 PM" src="https://user-images.githubusercontent.com/44467999/155192985-1ff83b6c-ab01-4f2c-8ca1-f645100fd1da.png">

<img width="481" alt="Screen Shot 2022-02-22 at 12 40 35 PM" src="https://user-images.githubusercontent.com/44467999/155192502-9387911e-867a-4a64-95ae-26a9a1c3311a.png">



