### PR TITLE
Quick Fix of adding User Free Response Data Button

### DIFF
--- a/edu_storybook/templates/admin/index.html
+++ b/edu_storybook/templates/admin/index.html
@@ -128,6 +128,8 @@
                 aria-pressed="true">User Data</a>
             <a href="/api/admin/download/action" target="_blank" class="btn btn-atts bg-info" role="button"
                 aria-pressed="true">Action Data</a>
+            <a href="/api/admin/download/free_response" target="_blank" class="btn btn-atts bg-info" role="button"
+                aria-pressed="true">User Free Response Data</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Added a Free Response Data Button to have the admin download the data
Fixes issue #420 
<img width="1435" alt="Screen Shot 2022-05-03 at 4 20 57 PM" src="https://user-images.githubusercontent.com/44401128/166559431-12dd6248-4ce3-4dc0-8a51-9a48ebf9cae2.png">

