### PR TITLE
Stripped Newline From oracle_dir To Prevent Linux "Oracle Net Admin Error" Hang Ups

### DIFF
--- a/edu_storybook/core/db.py
+++ b/edu_storybook/core/db.py
@@ -27,7 +27,7 @@ assert oracle_lib_dir is not None and oracle_lib_dir != '', config['sensitives']
     'folders']['oracle_dir'] + ' is empty, it needs the filepath to the Oracle Instant Client'
 
 try:
-    cx_Oracle.init_oracle_client(lib_dir=oracle_lib_dir)
+    cx_Oracle.init_oracle_client(lib_dir=oracle_lib_dir.strip())
 except cx_Oracle.ProgrammingError:
     c_db_log.warning("Ignoring cx_Oracle's stupid initialization error")
 


### PR DESCRIPTION
When reading the Oracle Instant Client location, a newline is added to the single line that is read. This throws off Ubuntu when it is looking for the specified folder. Adding the `strip` string method clears the newline, and any other trailing or leading white space so that Ubuntu can correctly locate the Oracle Instant Client.