### PR TITLE
Fixed the bug to make "Prev" and "Next" links invisible at the beginning and end of storybook respectively

### DIFF
--- a/edu_storybook/templates/storyboard/viewer.html
+++ b/edu_storybook/templates/storyboard/viewer.html
@@ -39,12 +39,12 @@ $(document).ready(() => {
             </div>
         </div>
 
-        <a class="carousel-control-prev text-dark" style="display:block" href="/storyboard/¶id_of_book/¶prev_page_num"
+        <a class="carousel-control-prev text-dark" style="¶show_prev_link" href="/storyboard/¶id_of_book/¶prev_page_num"
             data-mdb-target="#carouselDarkVariant" role="button" data-slide="prev" onclick="turn_page_backward()">
             &lt; Previous <span class="carousel-control-prev-icon" aria-hidden="true"></span>
                 <span class="sr-only">Previous</span>
         </a>
-        <a class="carousel-control-next text-dark" style="display:block" href="/storyboard/¶id_of_book/¶next_page_num"
+        <a class="carousel-control-next text-dark" style="¶show_next_link" href="/storyboard/¶id_of_book/¶next_page_num"
             data-mdb-target="#carouselDarkVariant" role="button" data-slide="next" onclick="turn_page_forward()"> Next >
             <span class="carousel-control-next-icon" aria-hidden="true"></span>
             <span class="sr-only">Next</span>


### PR DESCRIPTION
#501 

<img width="1440" alt="Screen Shot 2022-05-14 at 6 50 09 PM" src="https://user-images.githubusercontent.com/45160752/168450518-9c595c12-dbf3-4db8-83b3-7da76f7ea68d.png">


<img width="1440" alt="Screen Shot 2022-05-14 at 6 50 27 PM" src="https://user-images.githubusercontent.com/45160752/168450520-44fec6c4-12c7-4652-9308-dccb72a53b62.png">
